### PR TITLE
CI: Use scss-lint for SCSS linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .sass-cache
-
+Gemfile.lock
 bower_components
 node_modules
-
-.idea

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,2 @@
+exclude: 'vendor/**'
+scss_files: ['dist/**/*.scss', 'src/**/*.scss']

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,2 +1,46 @@
-exclude: 'vendor/**'
-scss_files: ['dist/**/*.scss', 'src/**/*.scss']
+---
+linters:
+  Comment:
+    enabled: false
+  DeclarationOrder:
+    enabled: false
+  DuplicateProperty:
+    enabled: false
+  ElsePlacement:
+    enabled: false
+  EmptyLineBetweenBlocks:
+    enabled: false
+  HexLength:
+    enabled: false
+  HexNotation:
+    enabled: false
+  Indentation:
+    enabled: false
+  LeadingZero:
+    enabled: false
+  NameFormat:
+    enabled: false
+  NestingDepth:
+    enabled: false
+  PlaceholderInExtend:
+    enabled: false
+  PropertySortOrder:
+    enabled: false
+  QualifyingElement:
+    enabled: false
+  SelectorDepth:
+    enabled: false
+  SelectorFormat:
+    enabled: false
+  SpaceAfterComma:
+    enabled: false
+  SpaceBetweenParens:
+    enabled: false
+  StringQuotes:
+    enabled: false
+  UnnecessaryParentReference:
+    enabled: false
+  VendorPrefixes:
+    enabled: false
+  ZeroUnit:
+    enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,4 +1,8 @@
 ---
+exclude:
+  - 'node_modules/**/*'
+  - 'vendor/**/*'
+# TODO FIXME: Delete the following lines
 linters:
   Comment:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'scss-lint'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'scss_lint/rake_task'
+
+SCSSLint::RakeTask.new(:scss_lint)
+
+task default: [:scss_lint]

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  ruby:
+    version: ruby-2.1.5
+test:
+  override:
+    - bundle exec rake

--- a/dist/fonts/fc-icons.css
+++ b/dist/fonts/fc-icons.css
@@ -26,15 +26,15 @@
 }
 
 [class^="fci-"]:before,
-[class*=" fci-"]:before{
+[class*=" fci-"]:before {
   @extend .fci-icon;
 }
 
-.fci-go-to-arrow:before { content: "\E001" }
-.fci-menu-icon:before { content: "\E002" }
-.fci-tick:before { content: "\E003" }
-.fci-user-icon:before { content: "\E004" }
-.fci-phone-circled:before { content: "\E005" }
+.fci-go-to-arrow:before { content: "\E001"; }
+.fci-menu-icon:before { content: "\E002"; }
+.fci-tick:before { content: "\E003"; }
+.fci-user-icon:before { content: "\E004"; }
+.fci-phone-circled:before { content: "\E005"; }
 
 
 .list-checked > *:before,


### PR DESCRIPTION
:information_desk_person: These changes add the [`scss-lint`](https://github.com/causes/scss-lint) gem and an initial configuration for CircleCI.

Note that the build will fail until some SCSS files are added to this repository. :smiley_cat: 