### PR TITLE
Fixes and adjustments

### DIFF
--- a/dist/sass/_mixins/structure.scss
+++ b/dist/sass/_mixins/structure.scss
@@ -348,7 +348,7 @@ $colRatio: 1;
 %wrapPlaceholder {
   @include centerBlock(0,true);
   width: 100%;
-  max-width: 980px;
+  max-width: 1200px;
 }
 
 @mixin wrapThis($padding: false, $breakPoints: (false false)) {

--- a/dist/sass/_variables/misc.scss
+++ b/dist/sass/_variables/misc.scss
@@ -4,6 +4,7 @@
 //
 // Styleguide 5.0
 
+
 // Ratios
 //
 // $ratio - ratio used for defining the columns and font proportions

--- a/dist/sass/general/go-to-links.scss
+++ b/dist/sass/general/go-to-links.scss
@@ -3,15 +3,18 @@
 \* ---------------------------------------------------------------------- */
 
 $goToLinkSize: rem(4);
+
 .go-to-link {
-  @include borderRadius(50,'%');
-  @include posAbs(-2,0,false,0);
-  @include centerBlock(0,true);
+  @include borderRadius(50, '%');
+  @include posAbs(negative($goToLinkSize / 2), 0, false, 0);
+  @include centerBlock(0, true);
+
   display: block;
   z-index: 2;
   width: $goToLinkSize;
   height: $goToLinkSize;
-  line-height: $goToLinkSize / 2;
+  font-size: $goToLinkSize / 3;
+  line-height: $goToLinkSize / 1.5;
   text-align: center;
   background: inherit;
 
@@ -19,8 +22,8 @@ $goToLinkSize: rem(4);
     @include centerBlock(0.8,true);
   }
 
-  &:hover path {
-    fill: $ColorBrand5;
+  &:hover {
+    text-decoration: none;
   }
 
   // other go to links colors

--- a/dist/sass/style.scss
+++ b/dist/sass/style.scss
@@ -432,7 +432,7 @@ th {
 //
 // variables.rem
 
-$REMsupport: false;
+$REMsupport: false!default;
 
 
 

--- a/dist/style.css
+++ b/dist/style.css
@@ -585,7 +585,7 @@ td, th {
 .wrap, .wrap--nopad, .wrap--form {
   margin: 0 auto;
   width: 100%;
-  max-width: 980px; }
+  max-width: 1200px; }
 
 /* ---------------------------------------------------------------------- *\
   HTML STRUCTURE
@@ -1299,13 +1299,14 @@ h1, h2, h3, h4, h5, h6 {
   z-index: 2;
   width: 64px;
   height: 64px;
-  line-height: 32px;
+  font-size: 21.33333px;
+  line-height: 42.66667px;
   text-align: center;
   background: inherit; }
   .go-to-link svg {
     margin: 12.8px auto; }
-  .go-to-link:hover path {
-    fill: #ff4e00; }
+  .go-to-link:hover {
+    text-decoration: none; }
   .bg-1 .go-to-link path {
     fill: #3a77c1; }
   .bg-1 .go-to-link:hover path {

--- a/src/sass/_mixins/structure.scss
+++ b/src/sass/_mixins/structure.scss
@@ -348,7 +348,7 @@ $colRatio: 1;
 %wrapPlaceholder {
   @include centerBlock(0,true);
   width: 100%;
-  max-width: 980px;
+  max-width: 1200px;
 }
 
 @mixin wrapThis($padding: false, $breakPoints: (false false)) {

--- a/src/sass/_variables/misc.scss
+++ b/src/sass/_variables/misc.scss
@@ -4,6 +4,7 @@
 //
 // Styleguide 5.0
 
+
 // Ratios
 //
 // $ratio - ratio used for defining the columns and font proportions

--- a/src/sass/general/go-to-links.scss
+++ b/src/sass/general/go-to-links.scss
@@ -3,15 +3,18 @@
 \* ---------------------------------------------------------------------- */
 
 $goToLinkSize: rem(4);
+
 .go-to-link {
-  @include borderRadius(50,'%');
-  @include posAbs(-2,0,false,0);
-  @include centerBlock(0,true);
+  @include borderRadius(50, '%');
+  @include posAbs(negative($goToLinkSize / 2), 0, false, 0);
+  @include centerBlock(0, true);
+
   display: block;
   z-index: 2;
   width: $goToLinkSize;
   height: $goToLinkSize;
-  line-height: $goToLinkSize / 2;
+  font-size: $goToLinkSize / 3;
+  line-height: $goToLinkSize / 1.5;
   text-align: center;
   background: inherit;
 
@@ -19,8 +22,8 @@ $goToLinkSize: rem(4);
     @include centerBlock(0.8,true);
   }
 
-  &:hover path {
-    fill: $ColorBrand5;
+  &:hover {
+    text-decoration: none;
   }
 
   // other go to links colors

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -4,7 +4,7 @@
 //
 // variables.rem
 
-$REMsupport: false;
+$REMsupport: false!default;
 
 
 


### PR DESCRIPTION
- changed the max-width for the wrapper (from 980 to 1200px)
- decreased the importance of $REMsupport so it can be overwritten in the build step of projects were SASS-common is used
- fixed the go-to-links issues