### PR TITLE
Ratio width mixin for elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/src/sass/_mixins/structure.scss
+++ b/src/sass/_mixins/structure.scss
@@ -427,3 +427,36 @@ $maxWrapWidth: 1200px;
   }
 }
 
+
+
+/* ---------------------------------------------------------------------- *\
+  RATIO WIDTH
+  Set the width of an element in a golden ratio with the page width
+
+    $rwMainCol: the ratio for the element
+    $rwOtherCols: ratio for missing columns or empty space
+    $rwCenter: center the element horizontally
+    $rwBrakePoints: apply the change only between two brakepoints
+
+    e.g: @include ratioWidth(5, 3 2, true, $bpMobilePortrait $bpDesktop);
+
+\* ---------------------------------------------------------------------- */
+
+@mixin ratioWidth($rwMainCol, $rwOtherCols: false, $rwCenter: false, $rwBrakePoints: false) {
+
+  @include breakPoints(first($rwBrakePoints), last($rwBrakePoints)) {
+    @if $rwOtherCols {
+        width: last(colsWidth(append($rwOtherCols, $rwMainCol))) * 1%;
+    } @else {
+      width: 100%;
+    }
+
+    @if $rwCenter {
+      @include centerBlock();
+    }
+  }
+}
+
+.test {
+  @include ratioWidth(5, 3 2, true, $bpMobilePortraitLarge $bpMobileLandscape);
+}

--- a/src/sass/_mixins/structure.scss
+++ b/src/sass/_mixins/structure.scss
@@ -456,7 +456,3 @@ $maxWrapWidth: 1200px;
     }
   }
 }
-
-.test {
-  @include ratioWidth(5, 3 2, true, $bpMobilePortraitLarge $bpMobileLandscape);
-}


### PR DESCRIPTION
RATIO WIDTH
Set the width of an element in a golden ratio with the page width

`$rwMainCol`: the ratio for the element
`$rwOtherCols`: ratio for missing columns or empty space
`$rwCenter`: center the element horizontally
`$rwBrakePoints`: apply the change only between two brakepoints

e.g: `@include ratioWidth(5, 3 2, true, $bpMobilePortrait $bpDesktop);`