### PR TITLE
Removed redundant url function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/src/sass/general/forms-v2.scss
+++ b/src/sass/general/forms-v2.scss
@@ -168,7 +168,7 @@
     &.is-loading:before {
       content: '';
       display: block;
-      background: url(path('input-loader.gif',image)) no-repeat center center;
+      background: path('input-loader.gif',image) no-repeat center center;
       width: 20px;
       height: 20px;
       position: absolute;


### PR DESCRIPTION
`path` already outputs the `url` function so there's no need to wrap one in the other.
Also, it suddenly started breaking Rails' asset pipeline :( 