### PR TITLE
Change adjacent (`+`) selector to sibling (`~`)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-common",
-  "version": "2.7.15",
+  "version": "2.7.16",
   "description": "Collection of the SASS mixins used to style the Funding Circle pages.",
   "repository": {
     "type": "git",

--- a/src/sass/general/forms-v2.scss
+++ b/src/sass/general/forms-v2.scss
@@ -491,7 +491,7 @@
       position: absolute;
     }
 
-    :focus + &,
+    :focus ~ &,
     &.is-visible {
       height: auto;
       padding: rem(.8 1);
@@ -500,7 +500,7 @@
 
     @include breakPoints(0, $formBreakpoint) {
 
-      :focus + &,
+      :focus ~ &,
       &.is-visible {
         margin-bottom: rem(1);
 
@@ -518,7 +518,7 @@
       left: 100%;
       margin-left: rem(1);
 
-      :focus + &:before,
+      :focus ~ &:before,
       &.is-visible:before {
         @include triangle(left, $tooltipBackground, ($tooltipArrowHeight * 2) $tooltipArrowHeight);
         top: rem(.8);


### PR DESCRIPTION
Fixes tooltip not showing when validation messages are present. By using
the adjacent  (`+`) selector, if there are any other elements after the
input, the tooltip will not show.