### PR TITLE
[AF-456] Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@FundingCircle/team-acquire-and-frontend-platform


### PR DESCRIPTION
### What does this PR do?
Adds @FundingCircle/team-acquire-and-frontend-platform as code owner.

### Where should the reviewer start?
`.github/CODEOWNERS`

### Any background context you want to provide?
All repos are to be owned by a single team at Funding Circle.

### Any specific implementation changes that would benefit highlighting?
*intentionally left blank*

### What are the relevant tickets / PRs?
- [x] JIRA :gem:: https://jira.fundingcircle.com/browse/AF-456
- [ ] **Blocked on**: https://github.com/FundingCircle/{app}/pull/{number}
- [ ] *Related*: https://github.com/FundingCircle/{app}/pull/{number}